### PR TITLE
Added upgrading for older .KBF files

### DIFF
--- a/kbf/data/file/kbf_file_upgrader.hpp
+++ b/kbf/data/file/kbf_file_upgrader.hpp
@@ -53,6 +53,12 @@ namespace kbf {
 			{ {1,0,6}, [this](rapidjson::Document& doc) { return upgradePartCache_1_0_6(doc); } },
 		};
 
+		bool upgradeDotKBF_1_2_0(rapidjson::Document& doc);
+		UpgradeLUT dotKBFUpgradeLUT{
+			{ {1,2,0}, [this](rapidjson::Document& doc) { return upgradeDotKBF_1_2_0(doc); } },
+		};
+
+
 		UpgradeResult UPGRADE_NO_OP(SemanticVersion ver, rapidjson::Document& doc) { return UpgradeResult::NO_UPGRADE_NEEDED; }
 	};
 


### PR DESCRIPTION
When importing .KBF files from older version they'd fail.
Just added an upgrade for .KBF files.

In this KBF files are treated as archives, meaning no upgraded file is created.
if it should just dont merge the lines
```
57        // didn't find a way for upgradeFileUsingLUT to return no upgrade needed only woth .KBF
58        if (fileType == KbfFileType::DOT_KBF) return UpgradeResult::NO_UPGRADE_NEEDED;
59
```