### PR TITLE
Just QoL... and a typo

### DIFF
--- a/kbf/gui/panels/presets/combine_presets_panel.cpp
+++ b/kbf/gui/panels/presets/combine_presets_panel.cpp
@@ -21,12 +21,13 @@ namespace kbf {
         const std::string& strID,
         const KBFDataManager& dataManager,
         ImFont* wsSymbolFont,
-        ImFont* wsArmourFont
+        ImFont* wsArmourFont,
+        std::string defaultBundle
     ) : iPanel(name, strID), dataManager{ dataManager }, wsSymbolFont{ wsSymbolFont }, wsArmourFont{ wsArmourFont } {
         preset = Preset{};
         preset.name = "New Combined Preset";
         preset.uuid = uuid::v4::UUID::New().String();
-        preset.bundle = PRESET_DEFAULT_BUNDLE;
+        preset.bundle = defaultBundle.empty() ? PRESET_DEFAULT_BUNDLE : defaultBundle;
         preset.female = true;
         preset.armour = ArmourSet{ ANY_ARMOUR_ID, false };
 

--- a/kbf/gui/panels/presets/combine_presets_panel.hpp
+++ b/kbf/gui/panels/presets/combine_presets_panel.hpp
@@ -19,7 +19,8 @@ namespace kbf {
 			const std::string& strID,
 			const KBFDataManager& dataManager,
 			ImFont* wsSymbolFont,
-			ImFont* wsArmourFont);
+			ImFont* wsArmourFont,
+			std::string defaultBundle = "");
 
 		bool draw() override;
 		void onCombine(std::function<void(Preset)> callback) { combineCallback = callback; }

--- a/kbf/gui/panels/presets/create_preset_panel.cpp
+++ b/kbf/gui/panels/presets/create_preset_panel.cpp
@@ -19,12 +19,13 @@ namespace kbf {
         const std::string& strID,
         const KBFDataManager& dataManager,
         ImFont* wsSymbolFont,
-        ImFont* wsArmourFont
+        ImFont* wsArmourFont,
+        std::string defaultBundle
     ) : iPanel(name, strID), dataManager{ dataManager }, wsSymbolFont{ wsSymbolFont }, wsArmourFont{ wsArmourFont } {
         preset        = Preset{};
         preset.name   = "New Preset";
         preset.uuid   = uuid::v4::UUID::New().String();
-        preset.bundle = PRESET_DEFAULT_BUNDLE;
+        preset.bundle = defaultBundle.empty() ? PRESET_DEFAULT_BUNDLE : defaultBundle;
         preset.female = true;
         preset.armour = ArmourSet{ ANY_ARMOUR_ID, false };
 

--- a/kbf/gui/panels/presets/create_preset_panel.hpp
+++ b/kbf/gui/panels/presets/create_preset_panel.hpp
@@ -19,7 +19,8 @@ namespace kbf {
 			const std::string& strID,
 			const KBFDataManager& dataManager,
 			ImFont* wsSymbolFont,
-			ImFont* wsArmourFont);
+			ImFont* wsArmourFont,
+			std::string defaultBundle = "");
 
 		bool draw() override;
 		void onCreate(std::function<void(Preset)> callback) { createCallback = callback; }

--- a/kbf/gui/panels/presets/import_fbs_presets_panel.hpp
+++ b/kbf/gui/panels/presets/import_fbs_presets_panel.hpp
@@ -31,6 +31,8 @@ namespace kbf {
 		std::string bundleName = "Imported FBS Presets";
 		bool presetsFemale = true;
 		std::vector<FBSPreset> presets;
+		std::unordered_set<std::string> selectedPresets;
+		char filterBuffer[128];
 
 		// Loading threading stuff
 		void postToMainThread(std::function<void()> func);
@@ -51,7 +53,7 @@ namespace kbf {
 		void drawPresetList(const std::vector<FBSPreset>& presets, bool autoSwitchOnly, const bool female);
 		void drawArmourSetName(const ArmourSet& armourSet, const float offsetBefore, const float offsetAfter);
 
-		std::vector<Preset> createPresetList(bool autoswitchOnly) const;
+		std::vector<Preset> createPresetList(bool autoswitchOnly, bool selectionsOnly) const;
 
 		std::function<void(std::vector<Preset>)> createCallback;
 		std::function<void()> cancelCallback;

--- a/kbf/gui/tabs/about/about_tab.cpp
+++ b/kbf/gui/tabs/about/about_tab.cpp
@@ -472,7 +472,7 @@ namespace kbf {
             WRAP_BULLET("-", "Fixed a bug causing players to not be fetched properly in online mode on some systems.");
             WRAP_BULLET("-", "Fixed a bug causing performance degradation when trying to fetch info for players that had not been set up yet (e.g. in tent).");
             WRAP_BULLET("-", "Fixed a bug causing preset dependencies of a preset group to not be correctly selected when selecting a preset group in the .kbf / .zip export panel.");
-            WRAP_BULLET("-", "Deferred initialization of KBF to the Main Menu scene to ensure global game data is always intiialized before being read.");
+            WRAP_BULLET("-", "Deferred initialization of KBF to the Main Menu scene to ensure global game data is always initialized before being read.");
             CImGui::Spacing();
         }
         if (CImGui::CollapsingHeader("v1.1.2")) {

--- a/kbf/gui/tabs/presets/presets_tab.cpp
+++ b/kbf/gui/tabs/presets/presets_tab.cpp
@@ -26,7 +26,7 @@ namespace kbf {
 
         bool canImportFBSpresets = dataManager.fbsDirectoryFound() && !importFBSPresetsPanel.isVisible();
         if (!canImportFBSpresets) CImGui::BeginDisabled();
-        if (CImGui::Button("Import FBS Presets as Bundle", buttonSize)) {
+        if (CImGui::Button("Import FBS Presets", buttonSize)) {
 			openImportFBSPresetsPanel();
         }
 		if (!canImportFBSpresets) CImGui::EndDisabled();

--- a/kbf/gui/tabs/presets/presets_tab.cpp
+++ b/kbf/gui/tabs/presets/presets_tab.cpp
@@ -39,14 +39,20 @@ namespace kbf {
                 drawBundleTab();
                 CImGui::EndTabItem();
             }
-            if (CImGui::IsItemClicked()) closePopouts();
+            if (CImGui::IsItemClicked()) { 
+                closePopouts(); 
+                inBundlesTab = true;
+            }
 
             if (CImGui::BeginTabItem("All Presets")) {
                 CImGui::Spacing();
                 drawPresetList();
                 CImGui::EndTabItem();
             }
-            if (CImGui::IsItemClicked()) closePopouts();
+            if (CImGui::IsItemClicked()) { 
+                closePopouts(); 
+                inBundlesTab = false; 
+            }
 
             CImGui::EndTabBar();
         }
@@ -545,7 +551,7 @@ namespace kbf {
     }
 
     void PresetsTab::openCreatePresetPanel() {
-        createPresetPanel.openNew("Create Preset", "CreatePresetPanel", dataManager, wsSymbolFont, wsArmourFont);
+        createPresetPanel.openNew("Create Preset", "CreatePresetPanel", dataManager, wsSymbolFont, wsArmourFont, getBundleViewed());
         createPresetPanel.get()->focus();
 
         createPresetPanel.get()->onCancel([&]() {
@@ -559,7 +565,7 @@ namespace kbf {
     }
 
     void PresetsTab::openCombinePresetsPanel() {
-        combinePresetsPanel.openNew("Combine Presets", "CombinePresetsPanel", dataManager, wsSymbolFont, wsArmourFont);
+        combinePresetsPanel.openNew("Combine Presets", "CombinePresetsPanel", dataManager, wsSymbolFont, wsArmourFont, getBundleViewed());
         combinePresetsPanel.get()->focus();
         combinePresetsPanel.get()->onCancel([&]() {
             combinePresetsPanel.close();
@@ -632,5 +638,7 @@ namespace kbf {
         });
 	}
 
-
+    std::string PresetsTab::getBundleViewed() {
+        return inBundlesTab ? bundleViewed : "";
+    }
 }

--- a/kbf/gui/tabs/presets/presets_tab.hpp
+++ b/kbf/gui/tabs/presets/presets_tab.hpp
@@ -52,6 +52,9 @@ namespace kbf {
 		ImFont* wsArmourFont;
 
 		std::function<void(std::string)> openPresetInEditorCb;
+
+		std::string getBundleViewed();
+		bool inBundlesTab = true;
 	};
 
 }


### PR DESCRIPTION
Yes, just 1 typo from the newest changelog.
> ...game data is always intiialized before being...

Changed the logic from the `ImportFBSPresetPanel` to add the ability to select which presets to import, the default behaviour is still to import every preset, unless at least 1 is selected. Also changed the button text from "Import FBS Presets as Bundle" to just "Import FBS Presets".

Changed both `CreatePresetPanel` and `CombinePresetPanel` to have an additional input variable `defaultBundle`, that by default is an empty string but when passed it changes de default value for the bundle textbox to that (`defaultBundle.empty() ? PRESET_DEFAULT_BUNDLE : defaultBundle;`)
And made logic in the presets tab to make that change work only when in the bundles tab and not the all presets tab.